### PR TITLE
Dev bugfix constructor

### DIFF
--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -16,7 +16,7 @@ setGeneric("aggregate.t", function(x, ...) standardGeneric("aggregate.t"))
     out = .cpMetadata(x,out)
     out@data@names = scidb_attributes(out)
     out@tResolution = as.numeric(difftime(x@tExtent[["max"]],x@tExtent[["min"]],x@tUnit))+1
-    out@temporal_dim = ""
+    # out@temporal_dim = ""
     return(out)
   } else {
     stop("Cannot aggregate over time with no temporal reference on the object")
@@ -72,7 +72,7 @@ setGeneric("aggregate.sp", function(x, ...) standardGeneric("aggregate.sp"))
     out = .scidbst_class(agg)
     out = .cpMetadata(x,out)
     out@data@names = scidb_attributes(out)
-    out@spatial_dims = list()
+    # out@spatial_dims = list()
 
     out@affine = out@affine %*% matrix(c(1,0,0,0,old_ncol,0,0,0,old_nrow),ncol=3,nrow=3)
 

--- a/R/getValues.R
+++ b/R/getValues.R
@@ -20,16 +20,13 @@ NULL
 #' @export
 setMethod("getValues", signature(x='scidbst', row='missing', nrows='missing'),
           function(x) {
-            if (length(dimnames(x)) > 2 ) {
+            ndims = length(dimnames(x))
+            if (ndims > 2 ) {
               stop("Too many dimensions detected. Try 'slice' to subset the image for example time.")
             }
 
-            if (! inMemory(x) ) {
-              if ( fromDisk(x) ) {
+            if (! hasValues(x) ) {
                 x <- readAll(x)
-              } else {
-                return( matrix(rep(NA, ncell(x) * nlayers(x)), ncol=nlayers(x)) )
-              }
             }
             #colnames(x@data@values) <- x@data@names
             x@data@names = scidb_attributes(x)

--- a/R/getterSetter.R
+++ b/R/getterSetter.R
@@ -9,7 +9,7 @@ setGeneric("getXDim",function(x) standardGeneric("getXDim"))
 #' @return The name of the spatia West-East dimension or the first dimension name
 #' @export
 setMethod("getXDim",signature(x="scidbst"),function(x){
-  if (x@isSpatial) {
+  if (length(x@spatial_dims) > 0 ) {
     return(x@spatial_dims$xdim)
   } else {
     return(dimensions(x)[2])
@@ -27,7 +27,7 @@ setGeneric("getYDim",function(x) standardGeneric("getYDim"))
 #' @return The name of the spatia North-South dimension or the first dimension name
 #' @export
 setMethod("getYDim",signature(x="scidbst"),function(x){
-  if (x@isSpatial) {
+  if (length(x@isSpatial) > 0) {
     return(x@spatial_dims$ydim)
   } else {
     return(dimensions(x)[1])
@@ -45,7 +45,7 @@ setGeneric("getTDim",function(x) standardGeneric("getTDim"))
 #' @return The temporal dimension name or the first dimension name
 #' @export
 setMethod("getTDim",signature(x="scidbst"),function(x){
-  if (x@isTemporal) {
+  if (length(x@temporal_dim) > 0) {
     return(x@temporal_dim)
   } else {
     return(dimensions(x)[1])

--- a/R/ncol.R
+++ b/R/ncol.R
@@ -8,16 +8,13 @@
 #' @export
 setMethod("ncol",signature(x="scidbst"),function(x) {
   if (x@isSpatial) {
-    extent = .calculateDimIndices(x,extent(x))
-    return(extent@xmax-extent@xmin+1)
-  } else if (x@isTemporal) {
-    return(as.numeric(difftime(x@tExtent[["max"]],x@tExtent[["min"]],x@tUnit))+1)
-  } else {
     lengths = .getLengths(x)
     if (length(lengths) == 1) {
       return(lengths[1])
     } else {
       return(lengths[getXDim(x)])
     }
+  } else if (x@isTemporal) {
+    return(as.numeric(difftime(x@tExtent[["max"]],x@tExtent[["min"]],x@tUnit))+1)
   }
 })

--- a/R/nrow.R
+++ b/R/nrow.R
@@ -8,17 +8,14 @@
 #' @export
 setMethod("nrow",signature(x="scidbst"),function(x) {
   if (x@isSpatial) {
-    #dim = x@spatial_dims$ydim
-    extent = .calculateDimIndices(x,extent(x))
-    return(extent@ymax-extent@ymin+1)
-  } else if (x@isTemporal){
-    return(1)
-  } else {
     lengths = .getLengths(x)
     if (length(lengths) == 1) {
       return(1)
     } else {
       return(lengths[getYDim(x)])
     }
+  } else if (x@isTemporal){
+    return(1)
   }
+  stop("Did not expect to go here.")
 })

--- a/R/readAll.R
+++ b/R/readAll.R
@@ -1,40 +1,28 @@
 #' @include scidbst-class.R
 NULL
 
-.materializeSCIDBValues = function(object, startrow, nrows=1, startcol=1, ncols=ncol(object)) {
-  if (length(dimensions(object))>2) {
-    stop("Array has more than two dimensions to fetch data in a raster format")
-    #TODO if time is referenced allow download of multiple timesteps, if needed
-  }
-  offs <- c((startrow - 1), (startcol - 1))
-  reg <- c(nrows, ncols)
+# Restructures the data from a SciDB array into the raster data format using matrices and index shifts
+# returns: scidbst object with data
+# note: testing with arrays containing multiple NA values fails, this strategy is not reliable right now
+.matrixStrategy = function(object,data) {
   result <- matrix(nrow = (ncol(object)) * (nrow(object)), ncol = nlayers(object))
-
-  extent = as.matrix(.calculateDimIndices(object,extent(object)))
-
-  cat("Downloading data...\n")
-  .data = iquery(object@name,return=T)
 
   dims = dimensions(object)
   ndims = length(dims)
 
-  if (nrow(.data) == 0) { #scidb does not return data. Stop here
-    stop("Image is empty.")
-  }
-
   for (b in 1:object@data@nlayers) {
     lname = object@data@names[b]
 
-    if (!all(is.na(.data[,lname]))) {
+    if (!all(is.na(data[,lname]))) {
 
       if (ndims == 2) {
         ydim = getYDim(object)
         xdim = getXDim(object)
 
         tmp = matrix(nrow=(nrow(object)),ncol=(ncol(object)))
-        m = .data[order(.data[,ydim],.data[,xdim]),]
-        start_y = min(.data[,ydim])
-        start_x = min(.data[,xdim])
+        m = .data[order(data[,ydim],data[,xdim]),]
+        start_y = min(data[,ydim])
+        start_x = min(data[,xdim])
         #shift x coordinates 0->1 and remove offset
         m[,xdim]=m[,xdim]+1-start_x
         #same for y
@@ -49,9 +37,9 @@ NULL
       } else { #number of dimensions is 1
         tdim = getTDim(object)
 
-        tmp = matrix(nrow=1,ncol=(max(.data[,tdim])-min(.data[,tdim])+1))
-        m = .data[order(.data[,tdim]),]
-        start_t = min(.data[,tdim])
+        tmp = matrix(nrow=1,ncol=(max(data[,tdim])-min(data[,tdim])+1))
+        m = data[order(data[,tdim]),]
+        start_t = min(data[,tdim])
         #shift t coordinates 0->1 and remove offset
         m[,tdim]=m[,tdim]+1-start_t
 
@@ -67,6 +55,94 @@ NULL
     }
   }
   colnames(result) = scidb_attributes(object)
+  object@data@values = result
+  return(object)
+}
+
+.spatialpointsStrategy = function(object,data) {
+
+  if (object@isSpatial) {
+    # res = t(apply(data,1,function(row) {
+    #   trans = .transformToWorld(affine,row[getXDim(object)],row[getYDim(object)])
+    #   row["sx"] = trans[1]
+    #   row["sy"] = trans[2]
+    #   return(row)
+    # })) #--- ~18s
+    coords = rbind(rep(1,nrow(data)),data[,getXDim(object)],data[,getYDim(object)])
+    res = t(object@affine %*% coords) #much faster than the previous
+    colnames(res) = c("sx","sy")
+
+    res = as.data.frame(res)
+    coordinates(res) <- ~sx+sy
+    crs(res) <- crs(object)
+    res = suppressWarnings(SpatialPixelsDataFrame(res,as.data.frame(data[,names(data) %in% scidb_attributes(object)])))
+    names(res@data) = scidb_attributes(object)
+    r = brick(res)
+
+    #copy all attributes from r to object
+    for (x in slotNames(r)) {
+      slot(object,x) <- slot(r,x)
+    }
+  } else if (object@isTemporal) { #hint: same as time handling from matrix strategy
+    result <- matrix(nrow = (ncol(object)) * (nrow(object)), ncol = nlayers(object))
+
+    dims = dimensions(object)
+    ndims = length(dims)
+
+      for (b in 1:object@data@nlayers) {
+        lname = object@data@names[b]
+
+        tdim = getTDim(object)
+
+        tmp = matrix(nrow=1,ncol=(max(data[,tdim])-min(data[,tdim])+1))
+        m = data[order(data[,tdim]),]
+        start_t = min(data[,tdim])
+        #shift t coordinates 0->1 and remove offset
+        m[,tdim]=m[,tdim]+1-start_t
+
+        tmp2 = matrix(m[,lname],nrow=1,ncol=length(unique(m[,tdim])),byrow=T)
+
+        tmp[1,unique(m[,tdim])] = tmp2
+        #restructure the matrix to a one dimensional vector
+        restruct = as.vector(t(tmp))
+
+
+        result[,b] = restruct
+
+      }
+    colnames(result) = scidb_attributes(object)
+    object@data@values = result
+  }
+  return(object)
+}
+
+.materializeSCIDBValues = function(object, method="MATRIX") {
+  if (length(dimensions(object))>2) {
+    stop("Array has more than two dimensions to fetch data in a raster format")
+    #TODO if time is referenced allow download of multiple timesteps, if needed
+  }
+  # offs <- c((startrow - 1), (startcol - 1))
+  # reg <- c(nrows, ncols)
+  #result <- matrix(nrow = (ncol(object)) * (nrow(object)), ncol = nlayers(object))
+
+  # extent = as.matrix(.calculateDimIndices(object,extent(object)))
+
+  cat("Downloading data...\n")
+  .data = iquery(object@name,return=T) #query scidb for data
+
+  if (nrow(.data) == 0) { #scidb does not return data. Stop here
+    stop("Image is empty.")
+  }
+
+  object@data@names = scidb_attributes(object)
+  object@data@nlayers = length(object@data@names)
+
+  if (toupper(method)=="MATRIX") {
+    result = .matrixStrategy(object,.data)
+  } else if (toupper(method)=="POINTS") {
+    result = .spatialpointsStrategy(object,.data)
+  }
+
   return(result)
 }
 
@@ -94,7 +170,7 @@ setMethod('readAll', signature(object='scidbst'),
             #   stop('cannot read values; there is no file associated with this scidbst raster inheriting thing')
             # }
             object@data@inmemory <- TRUE
-            object@data@values <- .materializeSCIDBValues(object, 1, object@nrows)
+            object <- .materializeSCIDBValues(object, method="POINTS")
             w <- getOption('warn')
             on.exit(options('warn' = w))
             options('warn'=-1)
@@ -102,6 +178,7 @@ setMethod('readAll', signature(object='scidbst'),
             object@data@min <- as.vector(rge[1,])
             object@data@max <- as.vector(rge[2,])
             object@data@haveminmax <- TRUE
+
             return(object)
           }
 )

--- a/R/regrid.R
+++ b/R/regrid.R
@@ -52,8 +52,8 @@ NULL
     origin.rw = .transformToWorld(x@affine,.starts[getXDim(x)],.starts[getYDim(x)])
 
     #create temporary matrix to calculate the new origin
-    help.matrix = cbin(origin.rw,-(scaled_matrix[,2:3]))
-    new.origin = help.matrix %*% c(1,.starts)
+    help.matrix = cbind(origin.rw,-(scaled_matrix[,2:3]))
+    new.origin = help.matrix %*% c(1,.starts[getXDim(x)],.starts[getYDim(x)])
 
     #bind new origin and the scaling parameter
     out.affine = cbind(new.origin,scaled_matrix[,2:3])

--- a/R/sampleRegular.R
+++ b/R/sampleRegular.R
@@ -36,10 +36,11 @@ setMethod('sampleRegular', signature(x='scidbst'),
               }
               rcut <- raster(x)
               firstrow <- 1
-              lastrow <- nrow(rcut)
+              # lastrow <- nrow(rcut) #take here nrow / ncols fields from raster
+              lastrow = x@nrows
               firstcol <- 1
-              lastcol <- ncol(rcut)
-
+              # lastcol <- ncol(rcut)
+              lastcol = x@ncols
             } else {
 
               rcut <- crop(raster(x), ext)

--- a/R/scidbst-class.R
+++ b/R/scidbst-class.R
@@ -117,10 +117,10 @@ scidbst = function(...){
 
   }
 
-  .attr = scidb_attributes(.scidb)
-  .scidb@data@names = .attr
-  .scidb@data@nlayers = length(.attr)
-  .scidb@data@fromdisk = TRUE
+  # .attr = scidb_attributes(.scidb)
+  # .scidb@data@names = .attr
+  # .scidb@data@nlayers = length(.attr)
+  # .scidb@data@fromdisk = FALSE
 
   return(.scidb)
 }

--- a/R/scidbsteval.R
+++ b/R/scidbsteval.R
@@ -76,7 +76,7 @@ if (!isGeneric("scidbsteval")) {
         # set adapt temporal reference
       }
     }
-    browser()
+
     D = paste(scidb:::build_attr_schema(scidb.obj),scidb:::build_dim_schema(scidb.obj, newstart=starts, newnames=dimnames, newlen=lengths, newchunk=chunks),sep="")
     scidb.obj = reshape_scidb(x=scidb.obj,schema=D)
 

--- a/R/scidbsteval.R
+++ b/R/scidbsteval.R
@@ -25,9 +25,9 @@ if (!isGeneric("scidbsteval")) {
     # if references are kept (not dropped)
     schema = scidb_coordinate_bounds(expr)
     starts = as.double(schema$start)
-    starts[is.infinite(starts)] = as.double(scidb:::.scidb_DIM_MAX)-1
+    # starts[is.infinite(starts)] = scidb:::.scidb_DIM_MAX
     lengths = as.double(schema$length)
-    lengths[is.infinite(lengths)] = as.double(scidb:::.scidb_DIM_MAX)-1
+    # lengths[is.infinite(lengths)] = scidb:::.scidb_DIM_MAX
     dimnames = dimensions(expr)
     chunks = as.double(scidb_coordinate_chunksize(expr))
 
@@ -61,10 +61,11 @@ if (!isGeneric("scidbsteval")) {
         # set adapt temporal reference
       }
     }
-    scidb.obj = reshape_scidb(scidb.obj,shape=lengths,dimnames=dimnames,start=starts,chunks=chunks)
-    # D = scidb:::build_dim_schema(scidb.obj, newstart=starts, newnames=dimnames, newlen=lengths, newchunk=chunks)
-    # query = sprintf("reshape(%s,%s%s)", scidb.obj@name, scidb:::build_attr_schema(scidb.obj), D)
-    # scidb.obj = scidb:::.scidbeval(query,depend=list(scidb.obj))
+    browser()
+    # scidb.obj = reshape_scidb(scidb.obj,shape=lengths,dimnames=dimnames,start=starts,chunks=chunks)
+    D = scidb:::build_dim_schema(scidb.obj, newstart=starts, newnames=dimnames, newlen=lengths, newchunk=chunks)
+    query = sprintf("reshape(%s,%s%s)", scidb.obj@name, scidb:::build_attr_schema(scidb.obj), D)
+    scidb.obj = scidb:::.scidbeval(query,depend=list(scidb.obj))
 
     #second store to adapt none dropping changes
     scidb.obj = scidbeval(scidb.obj,eval,name, gc, temp)

--- a/R/slice.R
+++ b/R/slice.R
@@ -35,6 +35,10 @@ if (!isGeneric("slice")) {
     # it remains temporal in R, but not in scidb => keep information, but set temporal to false
   }
 
+  if (d %in% x@spatial_dims) {
+    out@isSpatial = FALSE
+  }
+
   return(out)
 }
 

--- a/R/spplot.R
+++ b/R/spplot.R
@@ -18,6 +18,9 @@ setMethod("spplot", signature(obj="scidbst"),function (obj, maxpixels=50000, as.
   if (length(dimnames(obj)) > 2 ) {
     stop("Too many dimensions detected. Try 'slice' to make a 2D subset of the image.")
   }
+  if (!hasValues(obj)) {
+    obj = readAll(obj)
+  }
   attr_names = scidb_attributes(obj)
   #following: code from raster::spplot
   obj <- sampleRegular(obj, maxpixels, asRaster=TRUE, useGDAL=TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,9 +106,9 @@
 
     to@affine = from@affine
 
-    to@data@names = scidb_attributes(to)
-    to@data@nlayers = length(to@data@names)
-    to@data@fromdisk = TRUE
+    # to@data@names = scidb_attributes(to)
+    # to@data@nlayers = length(to@data@names)
+    # to@data@fromdisk = TRUE
 
 
     to@spatial_dims = from@spatial_dims
@@ -122,9 +122,9 @@
     to@sref = from@sref
     to@tref = from@tref
 
-    if (inMemory(from)) {
-      to@data@inmemory = FALSE
-    }
+    # if (inMemory(from)) {
+    #   to@data@inmemory = FALSE
+    # }
 
     return(to)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -133,6 +133,8 @@
 # Calculates dimension indices from spatial real world coordinates given by an extent
 # object: scidbst object
 # extent: extent object
+#
+# returns extent object
 .calculateDimIndices = function(object, extent) {
   ll = c(xmin(extent),ymin(extent))
   ur = c(xmax(extent),ymax(extent))
@@ -164,6 +166,8 @@
 # function to create a scidb array from a scidbst array, this approach copies the environment content (object promises)
 # rather than querying the scidb instance anew for the same information
 # x: scidbst object
+#
+# returns scidb object
 .toScidb = function(x) {
   res = scidb("")
   res@name = x@name

--- a/man/scidbsteval.Rd
+++ b/man/scidbsteval.Rd
@@ -33,7 +33,8 @@ evaluation of a scidbst object will also set the current spatial and/or temporal
 }
 \note{
 Using the similar function \code{scidbeval} function will also perform the storing operation, but it will not transfer
-the dimension references for space and/or time.
+the dimension references for space and/or time. Also, unbounded dimensions that are not dropped will be created
+as bounded dimensions by its minimum/maximum dimension value.
 }
 \examples{
 \dontrun{

--- a/man/scidbsteval.Rd
+++ b/man/scidbsteval.Rd
@@ -7,7 +7,7 @@
 \title{Executes cascaded operations and stores data in scidb under a given name}
 \usage{
 \S4method{scidbsteval}{scidbst,character}(expr, name, eval = TRUE,
-  gc = TRUE, temp = FALSE)
+  gc = TRUE, temp = FALSE, drop = TRUE)
 }
 \arguments{
 \item{expr}{The scidbst object}
@@ -19,6 +19,8 @@
 \item{gc}{A flag whether or not the result should be tied to the R garbage collector}
 
 \item{temp}{A flag wheter or not the resulting scidb array is temporary}
+
+\item{drop}{Whether or not to drop spatial or temporal references, when dimension is removed from array}
 }
 \value{
 The modified scidbst object


### PR DESCRIPTION
- scidbsteval function extended with a drop parameter in order to drop or maintain referenced dimensions after an aggregation function for example
- fixed a problem in the calculation of the affine transformation after regrid
- changed the "materialize" function to create the 'raster' component more reliable
- fixed a problem with the constructor
